### PR TITLE
Multi-GOPATH support

### DIFF
--- a/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
+++ b/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
@@ -119,7 +119,7 @@ public class GenMockeryActionHandler extends EditorActionHandler {
                     break;
                 }
 
-            if(mockeryPath.isEmpty())
+            if(!mockeryPath.isEmpty())
                 break;
         }
 

--- a/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
+++ b/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.util.EnvironmentUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.io.File
 
 import javax.swing.*;
 import java.nio.file.Path;

--- a/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
+++ b/src/ch/ricardo/plugins/intellij/mockery/action/GenMockeryActionHandler.java
@@ -114,7 +114,7 @@ public class GenMockeryActionHandler extends EditorActionHandler {
                 continue;
 
             for(String goPathBinExecutable : goPathBinFiles)
-                if(goPathBinExecutable.startsWith("mockery.")) {
+                if(goPathBinExecutable.equals("mockery") || goPathBinExecutable.equals("mockery.exe")) {
                     mockeryPath = new File(goPath + "/bin/mockery").getAbsolutePath();
                     break;
                 }


### PR DESCRIPTION
Adds support for GOPATH with multiple paths. 
Searches for Mockery executable in each of the sub-paths until match.